### PR TITLE
Friendly client certificate filenames

### DIFF
--- a/DoD/CA/Signing/README_CreateClientCert.md
+++ b/DoD/CA/Signing/README_CreateClientCert.md
@@ -10,19 +10,21 @@
 
 2. Create a Client private key
 
-       openssl genrsa -aes256 -out private/username.key.pem 2048
+       openssl genrsa -aes256 -out private/<username>.key.pem 2048
+
+   > Note: Replace `<username>.key.pem` with something like `Smith.John.A.key.pem` that makes a valid windows filename.
 
    Enter a secure password
 
 3. Create a certificate signing request.
 
-       openssl req -config signingca.cnf -key private/username.key.pem -new -sha256 -out csr/username.csr.pem
+       openssl req -config signingca.cnf -key private/<username>.key.pem -new -sha256 -out csr/<username>.csr.pem
 
    Enter the password you created for the private key
 
 4. Keep using the signing CA to sign the client certificate request.
 
-       openssl ca -config signingca.cnf -extensions usr_cert -days 365 -notext -md sha256 -in csr/username.csr.pem -out public/username.cert.pem
+       openssl ca -config signingca.cnf -extensions usr_cert -days 365 -notext -md sha256 -in csr/<username>.csr.pem -out public/<username>.cert.pem
 
    Note: Be sure to use the Signing CA's password to sign the certificate request.
 
@@ -32,7 +34,7 @@
 
 5. Verify the cert:
 
-       openssl x509 -noout -text -in public/username.cert.pem
+       openssl x509 -noout -text -in public/<username>.cert.pem
 
    The X509v3 Extended Key Usage should say `Client Authentication` & `Email Protection`
 


### PR DESCRIPTION
Added more obvious documentation for creating friendly client certificate filenames that won't overwrite each other